### PR TITLE
Recall socket recv until get a complete response.

### DIFF
--- a/pymodbus/exceptions.py
+++ b/pymodbus/exceptions.py
@@ -5,6 +5,8 @@ Pymodbus Exceptions
 Custom exceptions to be used in the Modbus code.
 '''
 
+class IncompleteFrame(Exception):
+    pass
 
 class ModbusException(Exception):
     ''' Base modbus exception '''


### PR DESCRIPTION
Socket recv waits until it gets some data from the host but
not necessarily the entire response that can be fragmented in
many packets. In this case it receives an incomplete frame
that is rejected by the frame handler.
This commit solves this issue by recalling socket recv until
get a complete modbus response.